### PR TITLE
Upgrade pretender to 1.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "qunit": "~1.18.0",
-    "pretender": "~0.9.0",
+    "pretender": "1.0.0",
     "Faker": "~3.0.0"
   }
 }


### PR DESCRIPTION
Unfortunately there's a bug in pretender.js library, which makes AJAX requests fail within ember's testrunners. The solution seems easy, as we only have to upgrade pretender.js.

Please refer to: https://github.com/pretenderjs/pretender/pull/130

By the way, are there any plans to upgrade mirage? Why do we have to use a forked version?
